### PR TITLE
Prevent duplicates when MOF has more than one of a given resource.

### DIFF
--- a/functions/Get-MOFRequiredModules.ps1
+++ b/functions/Get-MOFRequiredModules.ps1
@@ -21,7 +21,14 @@
     $requiredModulesinMof = @()
     Switch -Regex (Get-Content $mofFile)
     {
-        "ModuleName" {$requiredModulesInMof += $_.Split("`"")[1]}
+        "ModuleName" 
+        { 
+            $Module = $_.Split("`"")[1]
+            if ($requiredModulesInMof -notcontains $module)
+            {
+                $requiredModulesInMof += $Module
+            } 
+        }
         #Default {Write-Output $_}
     }
 


### PR DESCRIPTION
Using a large MOF with several hundred resources the function Get-MOFRequiredModules.ps1 can return hundreds of duplicates.  DSCEA then tries to copy the resources to the scan target repeatedly.  This can result in huge delays before the scans begin and can appear to the user that the process is stuck.