### PR TITLE
PSSession check

### DIFF
--- a/functions/Start-DSCEAscan.ps1
+++ b/functions/Start-DSCEAscan.ps1
@@ -180,8 +180,14 @@ param
                     else {
                         $session = New-PSSession -ComputerName $Computer
                     }
-                    Copy-DSCResource -PSSession $session -ModulestoCopy $ModulesRequired
-                    Remove-PSSession $session
+
+                    if ($Session) {
+                        Copy-DSCResource -PSSession $session -ModulestoCopy $ModulesRequired
+                                Remove-PSSession $session
+                    }
+                    else {
+                        Write-Warning "PSSession to copy required modules could not be setup. Could not copy required modules!"
+                    }
                 }
                 if($PSBoundParameters.ContainsKey('CimSession')) {
                     $DSCJob = Test-DSCConfiguration -ReferenceConfiguration $mofFile -CimSession $CimSession -AsJob | Wait-Job -Timeout $JobTimeout


### PR DESCRIPTION
Checking if PSSession was established. If not give a warning but continue with checking.
This also makes the check work if you use localhost as the target.

Pull Requests to Dev
- [x] Check to see if PowerShell shows any errors when running Import-Module DSCEA
- [x] Review any lingering issues that might still be open and close them if the new release fixes the issues